### PR TITLE
Add CSV input and prioritize sequences

### DIFF
--- a/Diffdock_IC50_codes/README.md
+++ b/Diffdock_IC50_codes/README.md
@@ -233,3 +233,16 @@ We sincerely thank:
 * Jacob Silterra for his help with the publishing and deployment of the code.
 * Arthur Deng, Nicholas Polizzi and Ben Fry for their critical contributions to part of the code in this repository. 
 * Wei Lu and Rachel Wu for pointing out some issues with the code.
+
+## Fine-tuning with DiffDock embeddings
+To create a dataset for training a regression model from DiffDock results, run:
+
+```bash
+python Diffdock_IC50_codes/prepare_regression_dataset.py <path_to_Diffdock_data> metadata.csv dataset.pt
+```
+
+The dataset can be used to fine-tune a Regression Transformer with:
+
+```bash
+python Diffdock_IC50_codes/finetune_regression_transformer.py dataset.pt run_dir --epochs 20 --batch_size 8
+```

--- a/Diffdock_IC50_codes/datasets/process_mols.py
+++ b/Diffdock_IC50_codes/datasets/process_mols.py
@@ -196,7 +196,12 @@ def new_extract_receptor_structure(seq, all_coords, complex_graph, neighbor_cuto
     node_feat = torch.tensor(feature_list, dtype=torch.float32)
 
     lm_embeddings = torch.tensor(np.concatenate(lm_embeddings, axis=0)) if lm_embeddings is not None else None
-    complex_graph['receptor'].x = torch.cat([node_feat, lm_embeddings], axis=1) if lm_embeddings is not None else node_feat
+    # store raw language model embeddings for later use
+    if lm_embeddings is not None:
+        complex_graph['receptor'].lm_embeddings = lm_embeddings
+        complex_graph['receptor'].x = torch.cat([node_feat, lm_embeddings], axis=1)
+    else:
+        complex_graph['receptor'].x = node_feat
     complex_graph['receptor'].pos = coords
     complex_graph['receptor'].side_chain_vecs = side_chain_vecs.float()
     complex_graph['receptor', 'rec_contact', 'receptor'].edge_index = edge_index

--- a/Diffdock_IC50_codes/embedding_inference.py
+++ b/Diffdock_IC50_codes/embedding_inference.py
@@ -1,0 +1,149 @@
+import os
+import copy
+import yaml
+import numpy as np
+import torch
+import pandas as pd
+from argparse import ArgumentParser, Namespace, FileType
+from functools import partial
+from torch_geometric.loader import DataLoader
+
+from datasets.process_mols import write_mol_with_coords
+from utils.diffusion_utils import t_to_sigma as t_to_sigma_compl, get_t_schedule
+from utils.inference_utils import InferenceDataset, set_nones
+from utils.sampling import randomize_position, sampling
+from utils.utils import get_model
+from rdkit.Chem import RemoveAllHs
+
+
+def get_parser():
+    parser = ArgumentParser()
+    parser.add_argument('--config', type=FileType('r'), default='default_inference_args.yaml')
+    parser.add_argument('--protein_ligand_csv', type=str, default=None,
+                        help='CSV with columns complex_name, ligand_description, protein_path, protein_sequence')
+    parser.add_argument('--protein_path', type=str, default=None)
+    parser.add_argument('--ligand_description', type=str, default=None)
+    parser.add_argument('--protein_sequence', type=str, default=None)
+    parser.add_argument('--complex_name', type=str, default='complex')
+    parser.add_argument('--out_dir', type=str, default='results')
+    return parser
+
+
+def main(args: Namespace) -> None:
+    if args.config:
+        config_dict = yaml.load(args.config, Loader=yaml.FullLoader)
+        arg_dict = args.__dict__
+        for key, value in config_dict.items():
+            arg_dict.setdefault(key, value)
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    with open(f'{args.model_dir}/model_parameters.yml') as f:
+        score_model_args = Namespace(**yaml.full_load(f))
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    t_to_sigma = partial(t_to_sigma_compl, args=score_model_args)
+
+    model = get_model(score_model_args, device, t_to_sigma=t_to_sigma, no_parallel=True, old=args.old_score_model)
+    state_dict = torch.load(f'{args.model_dir}/{args.ckpt}', map_location='cpu')
+    model.load_state_dict(state_dict, strict=True)
+    model = model.to(device)
+    model.eval()
+
+    if args.protein_ligand_csv is not None:
+        df = pd.read_csv(args.protein_ligand_csv)
+        complex_names = set_nones(df["complex_name"].tolist())
+        protein_files = set_nones(df["protein_path"].tolist())
+        ligand_descs = set_nones(df["ligand_description"].tolist())
+        protein_seqs = set_nones(df.get("protein_sequence", []).tolist()) if "protein_sequence" in df.columns else [None] * len(df)
+    else:
+        complex_names = [args.complex_name]
+        protein_files = [args.protein_path]
+        ligand_descs = [args.ligand_description]
+        protein_seqs = [args.protein_sequence]
+
+    complex_names = [n if n is not None else f"complex_{i}" for i, n in enumerate(complex_names)]
+
+    dataset = InferenceDataset(
+        out_dir=args.out_dir,
+        complex_names=complex_names,
+        protein_files=protein_files,
+        ligand_descriptions=ligand_descs,
+        protein_sequences=protein_seqs,
+        lm_embeddings=True,
+        receptor_radius=score_model_args.receptor_radius,
+        remove_hs=score_model_args.remove_hs,
+        c_alpha_max_neighbors=score_model_args.c_alpha_max_neighbors,
+        all_atoms=score_model_args.all_atoms,
+        atom_radius=score_model_args.atom_radius,
+        atom_max_neighbors=score_model_args.atom_max_neighbors,
+        knn_only_graph=not getattr(score_model_args, 'not_knn_only_graph', False),
+    )
+
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+
+    tr_schedule = get_t_schedule(sigma_schedule='expbeta', inference_steps=args.inference_steps)
+
+    for i, orig_complex_graph in enumerate(loader):
+        if not orig_complex_graph.success[0]:
+            continue
+        data_list = [copy.deepcopy(orig_complex_graph) for _ in range(args.samples_per_complex)]
+        randomize_position(data_list, score_model_args.no_torsion, False, score_model_args.tr_sigma_max)
+
+        data_list, confidence, final_embedding, final_complex_graph = sampling(
+            data_list=data_list,
+            model=model,
+            inference_steps=args.inference_steps,
+            tr_schedule=tr_schedule,
+            rot_schedule=tr_schedule,
+            tor_schedule=tr_schedule,
+            device=device,
+            t_to_sigma=t_to_sigma,
+            model_args=score_model_args,
+        )
+
+        ligand_pos = [
+            complex_graph['ligand'].pos.cpu().numpy() + orig_complex_graph.original_center.cpu().numpy()
+            for complex_graph in data_list
+        ]
+
+        if confidence is not None:
+            if confidence.dim() > 1:
+                confidence = confidence[:, 0]
+            confidence = confidence.cpu().numpy()
+            order = np.argsort(confidence)[::-1]
+            confidence = confidence[order]
+            ligand_pos = [ligand_pos[i] for i in order]
+        else:
+            confidence = [float('nan')] * len(ligand_pos)
+
+        name_field = orig_complex_graph['name']
+        complex_name = name_field if isinstance(name_field, str) else name_field[0]
+        write_dir = os.path.join(args.out_dir, complex_name)
+        os.makedirs(write_dir, exist_ok=True)
+        mol_pred = copy.deepcopy(orig_complex_graph.mol[0])
+        if score_model_args.remove_hs:
+            mol_pred = RemoveAllHs(mol_pred)
+        for rank, pos in enumerate(ligand_pos):
+            write_mol_with_coords(
+                mol_pred,
+                pos,
+                os.path.join(write_dir, f'rank{rank+1}_confidence{confidence[rank]:.2f}.sdf'),
+            )
+
+        np.save(os.path.join(write_dir, 'complex_embedding.npy'), final_embedding.cpu().numpy())
+        if hasattr(orig_complex_graph['receptor'], 'lm_embeddings'):
+            np.save(
+                os.path.join(write_dir, 'receptor_embedding.npy'),
+                orig_complex_graph['receptor'].lm_embeddings.cpu().numpy(),
+            )
+            if hasattr(orig_complex_graph['receptor'], 'cls_embedding'):
+                cls_emb = orig_complex_graph['receptor'].cls_embedding
+                if cls_emb.dim() > 1:
+                    cls_emb = cls_emb.mean(dim=0, keepdim=True)
+                np.save(os.path.join(write_dir, 'receptor_cls_embedding.npy'), cls_emb.cpu().numpy())
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    main(args)

--- a/Diffdock_IC50_codes/finetune_regression_transformer.py
+++ b/Diffdock_IC50_codes/finetune_regression_transformer.py
@@ -1,0 +1,141 @@
+import os
+import math
+import argparse
+from typing import List, Dict, Any
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader, random_split
+from transformers import XLNetModel
+
+from terminator.tokenization import ExpressionBertTokenizer
+
+
+class DockingDataset(Dataset):
+    """Dataset wrapping DiffDock embeddings and pIC50 values."""
+
+    def __init__(self, records: List[Dict[str, Any]], tokenizer: ExpressionBertTokenizer):
+        self.records = records
+        self.tokenizer = tokenizer
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def __getitem__(self, idx: int):
+        rec = self.records[idx]
+        tokenized = self.tokenizer(rec["compound"])
+        emb_list = []
+        if rec.get("protein_emb") is not None:
+            emb_list.append(torch.tensor(rec["protein_emb"], dtype=torch.float))
+        if rec.get("complex_emb") is not None:
+            emb_list.append(torch.tensor(rec["complex_emb"], dtype=torch.float))
+        features = torch.cat([e.flatten() for e in emb_list]) if emb_list else torch.empty(0)
+        label = torch.tensor(float(rec["pIC50"]), dtype=torch.float)
+        return tokenized, features, label
+
+
+class Collator:
+    def __init__(self, tokenizer: ExpressionBertTokenizer, feat_dim: int):
+        self.tokenizer = tokenizer
+        self.feat_dim = feat_dim
+
+    def __call__(self, batch):
+        tokens = [b[0] for b in batch]
+        feats = [b[1] for b in batch]
+        labels = torch.stack([b[2] for b in batch])
+
+        enc = self.tokenizer.pad(tokens, return_tensors="pt")
+        feat_batch = torch.zeros(len(feats), self.feat_dim)
+        for i, f in enumerate(feats):
+            feat_batch[i, : f.numel()] = f
+        return enc, feat_batch, labels
+
+
+class RegressionTransformerWithEmbeddings(nn.Module):
+    def __init__(self, base_model: str, feature_dim: int, hidden_dim: int = 256):
+        super().__init__()
+        self.transformer = XLNetModel.from_pretrained(base_model)
+        hdim = self.transformer.config.hidden_size
+        self.proj = nn.Linear(feature_dim, hdim)
+        self.out = nn.Sequential(nn.Dropout(0.1), nn.Linear(hdim * 2, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, 1))
+
+    def forward(self, input_ids, attention_mask, features):
+        out = self.transformer(input_ids=input_ids, attention_mask=attention_mask).last_hidden_state
+        pooled = out.mean(dim=1)
+        proj = self.proj(features)
+        x = torch.cat([pooled, proj], dim=1)
+        return self.out(x).squeeze(-1)
+
+
+def load_dataset(path: str, tokenizer: ExpressionBertTokenizer) -> DockingDataset:
+    records = torch.load(path)
+    return DockingDataset(records, tokenizer)
+
+
+def train(args: argparse.Namespace) -> None:
+    tokenizer = ExpressionBertTokenizer.from_pretrained(args.tokenizer)
+    dataset = load_dataset(args.dataset, tokenizer)
+    feat_dim = dataset[0][1].numel()
+
+    collator = Collator(tokenizer, feat_dim)
+    val_size = max(1, int(0.2 * len(dataset)))
+    train_size = len(dataset) - val_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True, collate_fn=collator)
+    val_loader = DataLoader(val_ds, batch_size=args.batch_size, shuffle=False, collate_fn=collator)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = RegressionTransformerWithEmbeddings(args.model, feat_dim, args.hidden_dim).to(device)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+    loss_fn = nn.MSELoss()
+
+    best_rmse = math.inf
+    os.makedirs(args.output, exist_ok=True)
+
+    for epoch in range(args.epochs):
+        model.train()
+        for enc, feats, labels in train_loader:
+            enc = {k: v.to(device) for k, v in enc.items()}
+            feats = feats.to(device)
+            labels = labels.to(device)
+            pred = model(**enc, features=feats)
+            loss = loss_fn(pred, labels)
+            optimizer.zero_grad()
+            loss.backward()
+            optimizer.step()
+
+        model.eval()
+        preds, labs = [], []
+        with torch.no_grad():
+            for enc, feats, labels in val_loader:
+                enc = {k: v.to(device) for k, v in enc.items()}
+                feats = feats.to(device)
+                pred = model(**enc, features=feats)
+                preds.extend(pred.cpu().tolist())
+                labs.extend(labels.tolist())
+        rmse = math.sqrt(sum((p - l) ** 2 for p, l in zip(preds, labs)) / len(labs))
+        if rmse < best_rmse:
+            best_rmse = rmse
+            torch.save(model.state_dict(), os.path.join(args.output, "best_model.pt"))
+        print(f"Epoch {epoch+1}/{args.epochs} RMSE: {rmse:.4f} (best {best_rmse:.4f})")
+
+
+def get_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Fine-tune Regression Transformer on DiffDock dataset")
+    parser.add_argument("dataset", help="Path to dataset file created with prepare_regression_dataset.py")
+    parser.add_argument("output", help="Directory to store checkpoints")
+    parser.add_argument("--model", default="xlnet-base-cased", help="Base transformer model")
+    parser.add_argument("--tokenizer", default="vocabs/smallmolecules.txt", help="Tokenizer path")
+    parser.add_argument("--batch_size", type=int, default=8)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--hidden_dim", type=int, default=256)
+    return parser
+
+
+if __name__ == "__main__":
+    parser = get_parser()
+    args = parser.parse_args()
+    train(args)

--- a/Diffdock_IC50_codes/prepare_regression_dataset.py
+++ b/Diffdock_IC50_codes/prepare_regression_dataset.py
@@ -1,0 +1,57 @@
+import os
+import argparse
+import numpy as np
+import pandas as pd
+import torch
+
+
+def load_embedding(path: str) -> np.ndarray:
+    """Load numpy array if file exists else return None."""
+    if os.path.exists(path):
+        return np.load(path)
+    return None
+
+
+def flatten_embedding(emb: np.ndarray) -> np.ndarray:
+    """Flatten 2D embedding to 1D."""
+    if emb is None:
+        return None
+    return emb.reshape(-1)
+
+
+def prepare_dataset(data_root: str, metadata_csv: str, output_file: str) -> None:
+    meta_df = pd.read_csv(metadata_csv)
+    records = []
+    for _, row in meta_df.iterrows():
+        name = row.get("Complex_name") or row.get("complex_name")
+        if not name:
+            continue
+        comp_dir = os.path.join(data_root, name)
+        ligand_emb = load_embedding(os.path.join(comp_dir, "ligand_embedding.npy"))
+        receptor_emb = load_embedding(os.path.join(comp_dir, "receptor_embedding.npy"))
+        if ligand_emb is None:
+            continue
+        ligand_emb = flatten_embedding(ligand_emb)
+        receptor_emb = flatten_embedding(receptor_emb)
+        pIC50 = row.get("pIC50") or row.get("pchembl_value")
+        records.append({
+            "name": name,
+            "compound": row.get("SMILES"),
+            "protein_emb": receptor_emb,
+            "complex_emb": ligand_emb,
+            "pIC50": pIC50,
+        })
+    torch.save(records, output_file)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Create dataset for regression transformer from DiffDock outputs")
+    parser.add_argument("data_root", help="Path to Diffdock_data directory")
+    parser.add_argument("metadata_csv", help="CSV with complex names and pIC50 values")
+    parser.add_argument("output", help="Output dataset file (pt)")
+    args = parser.parse_args()
+    prepare_dataset(args.data_root, args.metadata_csv, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/Diffdock_IC50_codes/utils/inference_utils.py
+++ b/Diffdock_IC50_codes/utils/inference_utils.py
@@ -52,20 +52,23 @@ def set_nones(l):
 
 
 def get_sequences(protein_files, protein_sequences):
+    """Return sequences prioritizing the provided sequence over PDB extraction."""
     new_sequences = []
     for i in range(len(protein_files)):
-        if protein_files[i] is not None:
+        if protein_sequences[i] is not None and str(protein_sequences[i]) != "nan":
+            new_sequences.append(protein_sequences[i])
+        elif protein_files[i] is not None:
             new_sequences.append(get_sequences_from_pdbfile(protein_files[i]))
         else:
-            new_sequences.append(protein_sequences[i])
+            new_sequences.append(None)
     return new_sequences
 
 
 def compute_ESM_embeddings(model, alphabet, labels, sequences):
+    """Compute per-residue ESMFold embeddings and CLS token representations."""
     # settings used
     toks_per_batch = 4096
     repr_layers = [33]
-    include = "per_tok"
     truncation_seq_length = 10000
 
     dataset = FastaBatchedDataset(labels, sequences)
@@ -77,6 +80,7 @@ def compute_ESM_embeddings(model, alphabet, labels, sequences):
     assert all(-(model.num_layers + 1) <= i <= model.num_layers for i in repr_layers)
     repr_layers = [(i + model.num_layers + 1) % (model.num_layers + 1) for i in repr_layers]
     embeddings = {}
+    cls_tokens = {}
 
     with torch.no_grad():
         for batch_idx, (labels, strs, toks) in enumerate(data_loader):
@@ -89,8 +93,10 @@ def compute_ESM_embeddings(model, alphabet, labels, sequences):
 
             for i, label in enumerate(labels):
                 truncate_len = min(truncation_seq_length, len(strs[i]))
-                embeddings[label] = representations[33][i, 1: truncate_len + 1].clone()
-    return embeddings
+                rep = representations[33][i]
+                cls_tokens[label] = rep[0].clone()
+                embeddings[label] = rep[1: truncate_len + 1].clone()
+    return embeddings, cls_tokens
 
 
 def generate_ESM_structure(model, filename, sequence):
@@ -159,19 +165,22 @@ class InferenceDataset(Dataset):
                 # labels.extend([complex_names[i] + '_chain_' + str(j) for j in range(len(s))])
                 labels.extend([f'{complex_names[i]}chain{j}' for j in range(len(s))])
 
-            lm_embeddings = compute_ESM_embeddings(model, alphabet, labels, sequences)
+            lm_embeddings, cls_tokens = compute_ESM_embeddings(model, alphabet, labels, sequences)
 
             self.lm_embeddings = []
+            self.cls_embeddings = []
             for i in range(len(protein_sequences)):
                 s = protein_sequences[i].split(':')
-                # self.lm_embeddings.append([lm_embeddings[f'{complex_names[i]}_chain_{j}'] for j in range(len(s))])
                 self.lm_embeddings.append([lm_embeddings[f'{complex_names[i]}chain{j}'] for j in range(len(s))])
+                self.cls_embeddings.append([cls_tokens[f'{complex_names[i]}chain{j}'] for j in range(len(s))])
 
         elif not lm_embeddings:
             self.lm_embeddings = [None] * len(self.complex_names)
+            self.cls_embeddings = [None] * len(self.complex_names)
 
         else:
             self.lm_embeddings = precomputed_lm_embeddings
+            self.cls_embeddings = [None] * len(self.complex_names)
 
         # generate structures with ESMFold
         if None in protein_files:
@@ -191,8 +200,11 @@ class InferenceDataset(Dataset):
 
     def get(self, idx):
 
-        name, protein_file, ligand_description, lm_embedding = \
-            self.complex_names[idx], self.protein_files[idx], self.ligand_descriptions[idx], self.lm_embeddings[idx]
+        name = self.complex_names[idx]
+        protein_file = self.protein_files[idx]
+        ligand_description = self.ligand_descriptions[idx]
+        lm_embedding = self.lm_embeddings[idx]
+        cls_embedding = self.cls_embeddings[idx] if hasattr(self, 'cls_embeddings') else None
 
         # build the pytorch geometric heterogeneous graph
         complex_graph = HeteroData()
@@ -232,6 +244,11 @@ class InferenceDataset(Dataset):
                 all_atoms=self.all_atoms,
                 atom_cutoff=self.atom_radius,
                 atom_max_neighbors=self.atom_max_neighbors)
+
+            if cls_embedding is not None:
+                complex_graph['receptor'].cls_embedding = torch.stack(
+                    [torch.tensor(e) for e in cls_embedding]
+                )
 
         except Exception as e:
             print(f'Skipping {name} because of the error:')


### PR DESCRIPTION
## Summary
- update `embedding_inference.py` to parse input from a csv table of complexes
- ensure complex name directories are correctly generated per entry
- modify helper routine to prioritize provided sequence over PDB when computing ESMFold embeddings

## Testing
- `python -m py_compile Diffdock_IC50_codes/embedding_inference.py`
- `python -m py_compile Diffdock_IC50_codes/utils/inference_utils.py Diffdock_IC50_codes/prepare_regression_dataset.py Diffdock_IC50_codes/finetune_regression_transformer.py`
- `python -m py_compile Diffdock_IC50_codes/datasets/process_mols.py`


------
https://chatgpt.com/codex/tasks/task_e_6855dc0c78a4832285ad12918dc4105b