### PR TITLE
Fix ESM sequence handling

### DIFF
--- a/Diffdock_IC50_codes/embedding_inference.py
+++ b/Diffdock_IC50_codes/embedding_inference.py
@@ -1,8 +1,3 @@
-
-신규
-+149
--0
-
 import os
 import copy
 import yaml

--- a/Diffdock_IC50_codes/utils/inference_utils.py
+++ b/Diffdock_IC50_codes/utils/inference_utils.py
@@ -52,12 +52,22 @@ def set_nones(l):
 
 
 def get_sequences(protein_files, protein_sequences):
+    """Return the sequence for each complex.
+
+    If a sequence is explicitly provided, use it. Otherwise extract the
+    sequence from the PDB file. This prioritises user provided sequences
+    over sequences parsed from PDB files.
+    """
+
     new_sequences = []
-    for i in range(len(protein_files)):
-        if protein_files[i] is not None:
-            new_sequences.append(get_sequences_from_pdbfile(protein_files[i]))
+    for pdb_file, seq in zip(protein_files, protein_sequences):
+        if seq is not None:
+            new_sequences.append(seq)
+        elif pdb_file is not None:
+            new_sequences.append(get_sequences_from_pdbfile(pdb_file))
         else:
-            new_sequences.append(protein_sequences[i])
+            new_sequences.append(None)
+
     return new_sequences
 
 


### PR DESCRIPTION
## Summary
- clean up leftover diff markers in `embedding_inference.py`
- prefer provided sequence over PDB when generating ESM embeddings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865e84d8900832282efcfc8a1ef3c1b