### PR TITLE
Handle mismatched receptor embeddings

### DIFF
--- a/Diffdock_IC50_codes/datasets/process_mols.py
+++ b/Diffdock_IC50_codes/datasets/process_mols.py
@@ -195,7 +195,7 @@ def new_extract_receptor_structure(seq, all_coords, complex_graph, neighbor_cuto
     feature_list = [[safe_index(allowable_features['possible_amino_acids'], res)] for res in res_names_list]
     node_feat = torch.tensor(feature_list, dtype=torch.float32)
 
-    lm_embeddings = torch.tensor(np.concatenate(lm_embeddings, axis=0)) if lm_embeddings is not None else None
+    lm_embeddings = torch.tensor(lm_embeddings) if lm_embeddings is not None else None
     # store raw language model embeddings for later use
     if lm_embeddings is not None:
         complex_graph['receptor'].lm_embeddings = lm_embeddings


### PR DESCRIPTION
## Summary
- load confidence model during embedding inference for proper ranking
- prefer PDB sequences when generating embeddings for docking and use provided sequences for saved embeddings
- save embeddings from the provided sequence when available
- revert cropping logic that truncated receptor embeddings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a6f65ee083229590010333629b0e