### PR TITLE
Handle embedding length mismatch

### DIFF
--- a/Diffdock_IC50_codes/utils/inference_utils.py
+++ b/Diffdock_IC50_codes/utils/inference_utils.py
@@ -4,52 +4,49 @@ import pickle
 import numpy as np
 
 import torch
-from Bio.PDB import PDBParser
+import prody as pr
 from esm import FastaBatchedDataset, pretrained
 from rdkit.Chem import AddHs, MolFromSmiles
 from torch_geometric.data import Dataset, HeteroData
 import esm
 
 from datasets.constants import three_to_one
-from datasets.process_mols import generate_conformer, read_molecule, get_lig_graph_with_matching, moad_extract_receptor_structure
+from datasets.process_mols import (
+    generate_conformer,
+    read_molecule,
+    get_lig_graph_with_matching,
+    moad_extract_receptor_structure,
+)
 
 
 def get_sequences_from_pdbfile(file_path):
-    biopython_parser = PDBParser()
-    structure = biopython_parser.get_structure('random_id', file_path)
-    structure = structure[0]
-    sequence = None
-    for i, chain in enumerate(structure):
-        seq = ''
-        for res_idx, residue in enumerate(chain):
-            if residue.get_resname() == 'HOH':
+    """Return the sequence for each chain in ``file_path``.
+
+    The extraction mimics ``moad_extract_receptor_structure`` by relying on
+    ProDy for parsing while falling back to ``three_to_one`` for residue names
+    that are not standard. Unknown amino acids are replaced by ``"-"`` so the
+    sequence length matches the parsed coordinates.
+    """
+
+    pdb = pr.parsePDB(file_path)
+    hv = pdb.getHierView()
+    sequences = []
+
+    for chain in hv:
+        chain_seq = []
+        for residue in chain:
+            atoms = {a.getName() for a in residue}
+            if not {"CA", "N", "C"}.issubset(atoms):
                 continue
-            residue_coords = []
-            c_alpha, n, c = None, None, None
-            for atom in residue:
-                if atom.name == 'CA':
-                    c_alpha = list(atom.get_vector())
-                if atom.name == 'N':
-                    n = list(atom.get_vector())
-                if atom.name == 'C':
-                    c = list(atom.get_vector())
-            if c_alpha != None and n != None and c != None:  # only append residue if it is an amino acid
-                try:
-                    seq += three_to_one[residue.get_resname()]
-                except Exception as e:
-                    seq += '-'
-                    print("encountered unknown AA: ", residue.get_resname(), ' in the complex. Replacing it with a dash - .')
+            resname = residue.getResname()
+            chain_seq.append(three_to_one.get(resname, "-"))
+        sequences.append("".join(chain_seq))
 
-        if sequence is None:
-            sequence = seq
-        else:
-            sequence += (":" + seq)
-
-    return sequence
+    return ":".join(sequences)
 
 
 def set_nones(l):
-    return [s if str(s) != 'nan' else None for s in l]
+    return [s if str(s) != "nan" else None for s in l]
 
 
 def get_sequences(protein_files, protein_sequences, prefer_pdb: bool = False):
@@ -90,28 +87,36 @@ def compute_ESM_embeddings(model, alphabet, labels, sequences):
     dataset = FastaBatchedDataset(labels, sequences)
     batches = dataset.get_batch_indices(toks_per_batch, extra_toks_per_seq=1)
     data_loader = torch.utils.data.DataLoader(
-        dataset, collate_fn=alphabet.get_batch_converter(truncation_seq_length), batch_sampler=batches
+        dataset,
+        collate_fn=alphabet.get_batch_converter(truncation_seq_length),
+        batch_sampler=batches,
     )
 
     assert all(-(model.num_layers + 1) <= i <= model.num_layers for i in repr_layers)
-    repr_layers = [(i + model.num_layers + 1) % (model.num_layers + 1) for i in repr_layers]
+    repr_layers = [
+        (i + model.num_layers + 1) % (model.num_layers + 1) for i in repr_layers
+    ]
     embeddings = {}
     cls_tokens = {}
 
     with torch.no_grad():
         for batch_idx, (labels, strs, toks) in enumerate(data_loader):
-            print(f"Processing {batch_idx + 1} of {len(batches)} batches ({toks.size(0)} sequences)")
+            print(
+                f"Processing {batch_idx + 1} of {len(batches)} batches ({toks.size(0)} sequences)"
+            )
             if torch.cuda.is_available():
                 toks = toks.to(device="cuda", non_blocking=True)
 
             out = model(toks, repr_layers=repr_layers, return_contacts=False)
-            representations = {layer: t.to(device="cpu") for layer, t in out["representations"].items()}
+            representations = {
+                layer: t.to(device="cpu") for layer, t in out["representations"].items()
+            }
 
             for i, label in enumerate(labels):
                 truncate_len = min(truncation_seq_length, len(strs[i]))
                 rep = representations[33][i]
                 cls_tokens[label] = rep[0].clone()
-                embeddings[label] = rep[1: truncate_len + 1].clone()
+                embeddings[label] = rep[1 : truncate_len + 1].clone()
     return embeddings, cls_tokens
 
 
@@ -129,8 +134,8 @@ def generate_ESM_structure(model, filename, sequence):
                 f.write(output)
                 print("saved", filename)
         except RuntimeError as e:
-            if 'out of memory' in str(e):
-                print('| WARNING: ran out of memory on chunk_size', chunk_size)
+            if "out of memory" in str(e):
+                print("| WARNING: ran out of memory on chunk_size", chunk_size)
                 for p in model.parameters():
                     if p.grad is not None:
                         del p.grad  # free some memory
@@ -147,9 +152,23 @@ def generate_ESM_structure(model, filename, sequence):
 
 
 class InferenceDataset(Dataset):
-    def __init__(self, out_dir, complex_names, protein_files, ligand_descriptions, protein_sequences, lm_embeddings,
-                 receptor_radius=30, c_alpha_max_neighbors=None, precomputed_lm_embeddings=None,
-                 remove_hs=False, all_atoms=False, atom_radius=5, atom_max_neighbors=None, knn_only_graph=False):
+    def __init__(
+        self,
+        out_dir,
+        complex_names,
+        protein_files,
+        ligand_descriptions,
+        protein_sequences,
+        lm_embeddings,
+        receptor_radius=30,
+        c_alpha_max_neighbors=None,
+        precomputed_lm_embeddings=None,
+        remove_hs=False,
+        all_atoms=False,
+        atom_radius=5,
+        atom_max_neighbors=None,
+        knn_only_graph=False,
+    ):
 
         super(InferenceDataset, self).__init__()
         self.receptor_radius = receptor_radius
@@ -165,7 +184,9 @@ class InferenceDataset(Dataset):
         self.protein_sequences = protein_sequences
 
         # generate LM embeddings
-        if lm_embeddings and (precomputed_lm_embeddings is None or precomputed_lm_embeddings[0] is None):
+        if lm_embeddings and (
+            precomputed_lm_embeddings is None or precomputed_lm_embeddings[0] is None
+        ):
             print("Generating ESM language model embeddings")
             model_location = "esm2_t33_650M_UR50D"
             model, alphabet = pretrained.load_model_and_alphabet(model_location)
@@ -173,32 +194,55 @@ class InferenceDataset(Dataset):
             if torch.cuda.is_available():
                 model = model.cuda()
 
-            docking_sequences = get_sequences(protein_files, protein_sequences, prefer_pdb=True)
-            save_sequences = get_sequences(protein_files, protein_sequences, prefer_pdb=False)
+            docking_sequences = get_sequences(
+                protein_files, protein_sequences, prefer_pdb=True
+            )
+            save_sequences = get_sequences(
+                protein_files, protein_sequences, prefer_pdb=False
+            )
 
             labels, sequences = [], []
             for i in range(len(docking_sequences)):
-                s = docking_sequences[i].split(':')
+                s = docking_sequences[i].split(":")
                 sequences.extend(s)
-                labels.extend([f'{complex_names[i]}chain{j}' for j in range(len(s))])
-            docking_embeds, _ = compute_ESM_embeddings(model, alphabet, labels, sequences)
+                labels.extend([f"{complex_names[i]}chain{j}" for j in range(len(s))])
+            docking_embeds, _ = compute_ESM_embeddings(
+                model, alphabet, labels, sequences
+            )
 
             labels, sequences = [], []
             for i in range(len(save_sequences)):
-                s = save_sequences[i].split(':')
+                s = save_sequences[i].split(":")
                 sequences.extend(s)
-                labels.extend([f'{complex_names[i]}chain{j}' for j in range(len(s))])
-            save_embeds, cls_tokens = compute_ESM_embeddings(model, alphabet, labels, sequences)
+                labels.extend([f"{complex_names[i]}chain{j}" for j in range(len(s))])
+            save_embeds, cls_tokens = compute_ESM_embeddings(
+                model, alphabet, labels, sequences
+            )
 
             self.model_embeddings = []
             self.save_embeddings = []
             self.cls_embeddings = []
             for i in range(len(docking_sequences)):
-                d_chains = docking_sequences[i].split(':')
-                s_chains = save_sequences[i].split(':')
-                self.model_embeddings.append([docking_embeds[f'{complex_names[i]}chain{j}'] for j in range(len(d_chains))])
-                self.save_embeddings.append([save_embeds[f'{complex_names[i]}chain{j}'] for j in range(len(s_chains))])
-                self.cls_embeddings.append([cls_tokens[f'{complex_names[i]}chain{j}'] for j in range(len(s_chains))])
+                d_chains = docking_sequences[i].split(":")
+                s_chains = save_sequences[i].split(":")
+                self.model_embeddings.append(
+                    [
+                        docking_embeds[f"{complex_names[i]}chain{j}"]
+                        for j in range(len(d_chains))
+                    ]
+                )
+                self.save_embeddings.append(
+                    [
+                        save_embeds[f"{complex_names[i]}chain{j}"]
+                        for j in range(len(s_chains))
+                    ]
+                )
+                self.cls_embeddings.append(
+                    [
+                        cls_tokens[f"{complex_names[i]}chain{j}"]
+                        for j in range(len(s_chains))
+                    ]
+                )
 
         elif not lm_embeddings:
             self.model_embeddings = [None] * len(self.complex_names)
@@ -218,10 +262,14 @@ class InferenceDataset(Dataset):
 
             for i in range(len(protein_files)):
                 if protein_files[i] is None:
-                    self.protein_files[i] = f"{out_dir}/{complex_names[i]}/{complex_names[i]}_esmfold.pdb"
+                    self.protein_files[i] = (
+                        f"{out_dir}/{complex_names[i]}/{complex_names[i]}_esmfold.pdb"
+                    )
                     if not os.path.exists(self.protein_files[i]):
                         print("generating", self.protein_files[i])
-                        generate_ESM_structure(model, self.protein_files[i], protein_sequences[i])
+                        generate_ESM_structure(
+                            model, self.protein_files[i], protein_sequences[i]
+                        )
 
     def len(self):
         return len(self.complex_names)
@@ -233,11 +281,13 @@ class InferenceDataset(Dataset):
         ligand_description = self.ligand_descriptions[idx]
         model_embedding = self.model_embeddings[idx]
         save_embedding = self.save_embeddings[idx]
-        cls_embedding = self.cls_embeddings[idx] if hasattr(self, 'cls_embeddings') else None
+        cls_embedding = (
+            self.cls_embeddings[idx] if hasattr(self, "cls_embeddings") else None
+        )
 
         # build the pytorch geometric heterogeneous graph
         complex_graph = HeteroData()
-        complex_graph['name'] = name
+        complex_graph["name"] = name
 
         # parse the ligand, either from file or smile
         try:
@@ -249,19 +299,34 @@ class InferenceDataset(Dataset):
             else:
                 mol = read_molecule(ligand_description, remove_hs=False, sanitize=True)
                 if mol is None:
-                    raise Exception('RDKit could not read the molecule ', ligand_description)
+                    raise Exception(
+                        "RDKit could not read the molecule ", ligand_description
+                    )
                 mol.RemoveAllConformers()
                 mol = AddHs(mol)
                 generate_conformer(mol)
         except Exception as e:
-            print('Failed to read molecule ', ligand_description, ' We are skipping it. The reason is the exception: ', e)
-            complex_graph['success'] = False
+            print(
+                "Failed to read molecule ",
+                ligand_description,
+                " We are skipping it. The reason is the exception: ",
+                e,
+            )
+            complex_graph["success"] = False
             return complex_graph
 
         try:
             # parse the receptor from the pdb file
-            get_lig_graph_with_matching(mol, complex_graph, popsize=None, maxiter=None, matching=False, keep_original=False,
-                                        num_conformers=1, remove_hs=self.remove_hs)
+            get_lig_graph_with_matching(
+                mol,
+                complex_graph,
+                popsize=None,
+                maxiter=None,
+                matching=False,
+                keep_original=False,
+                num_conformers=1,
+                remove_hs=self.remove_hs,
+            )
 
             moad_extract_receptor_structure(
                 path=os.path.join(protein_file),
@@ -272,34 +337,51 @@ class InferenceDataset(Dataset):
                 knn_only_graph=self.knn_only_graph,
                 all_atoms=self.all_atoms,
                 atom_cutoff=self.atom_radius,
-                atom_max_neighbors=self.atom_max_neighbors)
+                atom_max_neighbors=self.atom_max_neighbors,
+            )
 
             if save_embedding is not None:
+                seq_lens = [len(s) for s in complex_graph["receptor"].sequence]
+                emb_lens = [
+                    e.shape[0] if isinstance(e, torch.Tensor) else e.shape[0]
+                    for e in save_embedding
+                ]
+                if seq_lens != emb_lens:
+                    print(
+                        f"Skipping {name} because residue lengths {seq_lens} do not match embedding lengths {emb_lens}."
+                    )
+                    complex_graph["success"] = False
+                    return complex_graph
+
                 if isinstance(save_embedding[0], torch.Tensor):
-                    complex_graph['receptor'].input_lm_embeddings = torch.cat(save_embedding, dim=0)
+                    complex_graph["receptor"].input_lm_embeddings = torch.cat(
+                        save_embedding, dim=0
+                    )
                 else:
-                    complex_graph['receptor'].input_lm_embeddings = torch.tensor(np.concatenate(save_embedding, axis=0))
+                    complex_graph["receptor"].input_lm_embeddings = torch.tensor(
+                        np.concatenate(save_embedding, axis=0)
+                    )
 
             if cls_embedding is not None:
-                complex_graph['receptor'].cls_embedding = torch.stack(
+                complex_graph["receptor"].cls_embedding = torch.stack(
                     [torch.tensor(e) for e in cls_embedding]
                 )
 
         except Exception as e:
-            print(f'Skipping {name} because of the error:')
+            print(f"Skipping {name} because of the error:")
             print(e)
-            complex_graph['success'] = False
+            complex_graph["success"] = False
             return complex_graph
 
-        protein_center = torch.mean(complex_graph['receptor'].pos, dim=0, keepdim=True)
-        complex_graph['receptor'].pos -= protein_center
+        protein_center = torch.mean(complex_graph["receptor"].pos, dim=0, keepdim=True)
+        complex_graph["receptor"].pos -= protein_center
         if self.all_atoms:
-            complex_graph['atom'].pos -= protein_center
+            complex_graph["atom"].pos -= protein_center
 
-        ligand_center = torch.mean(complex_graph['ligand'].pos, dim=0, keepdim=True)
-        complex_graph['ligand'].pos -= ligand_center
+        ligand_center = torch.mean(complex_graph["ligand"].pos, dim=0, keepdim=True)
+        complex_graph["ligand"].pos -= ligand_center
 
         complex_graph.original_center = protein_center
         complex_graph.mol = mol
-        complex_graph['success'] = True
+        complex_graph["success"] = True
         return complex_graph


### PR DESCRIPTION
## Summary
- refine `get_sequences_from_pdbfile` to mask unknown residues
- verify LM embedding length matches receptor sequence and skip on mismatch

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867000dda9883228408874b92f98aa6