### PR TITLE
Increase receptor size limit

### DIFF
--- a/Diffdock_IC50_codes/datasets/process_mols.py
+++ b/Diffdock_IC50_codes/datasets/process_mols.py
@@ -166,7 +166,7 @@ def new_extract_receptor_structure(seq, all_coords, complex_graph, neighbor_cuto
 
     # Build the k-NN graph
     coords = torch.tensor(all_coords[:, 1, :], dtype=torch.float)
-    if len(coords) > 3000:
+    if len(coords) > 4096:
         raise ValueError(f'The receptor is too large {len(coords)}')
     if knn_only_graph:
         edge_index = knn_graph(coords, k=max_neighbors if max_neighbors else 32)


### PR DESCRIPTION
## Summary
- expand receptor size threshold to 4096 residues

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686713f5f0008322bc93a729a8c940d6