### PR TITLE
Fix duplicate ProDy logs

### DIFF
--- a/Diffdock_IC50_codes/datasets/process_mols.py
+++ b/Diffdock_IC50_codes/datasets/process_mols.py
@@ -10,6 +10,10 @@ from rdkit.Geometry import Point3D
 from torch import cdist
 from torch_cluster import knn_graph
 import prody as pr
+from prody import LOGGER as PRODY_LOGGER
+
+# Avoid duplicated ProDy messages when parsing PDB files
+PRODY_LOGGER.propagate = False
 
 import torch.nn.functional as F
 


### PR DESCRIPTION
## Summary
- suppress propagation of ProDy logger to avoid duplicate "atoms parsed" messages

## Testing
- `python -m py_compile Diffdock_IC50_codes/datasets/process_mols.py`


------
https://chatgpt.com/codex/tasks/task_e_68672e65e4b48322a73a5942a249892c