### PR TITLE
Skip failing complexes during embedding inference

### DIFF
--- a/Diffdock_IC50_codes/embedding_inference.py
+++ b/Diffdock_IC50_codes/embedding_inference.py
@@ -155,7 +155,7 @@ def main(args: Namespace) -> None:
                 confidence_data_list=confidence_data_list,
                 confidence_model_args=confidence_args,
             )
-        except RuntimeError as e:
+        except Exception as e:
             if 'svd' in str(e).lower():
                 print(f"SVD failed for {complex_name}: {e}. Skipping.")
             else:

--- a/Diffdock_IC50_codes/utils/sampling.py
+++ b/Diffdock_IC50_codes/utils/sampling.py
@@ -214,19 +214,15 @@ def sampling(data_list, model, inference_steps, tr_schedule, rot_schedule, tor_s
                     set_time(confidence_complex_graph_batch, 0, 0, 0, 0, b, confidence_model_args.all_atoms, device)
                     try:
                         out = confidence_model(confidence_complex_graph_batch)
-                    except AssertionError as e:
-                        print("Confidence model failed:", e, "-> using -2.0 score")
-                        out = torch.full((b,), -2.0, device=device)
-                    except Exception:
-                        raise
+                    except Exception as e:
+                        print("Skipping complex due to confidence model error:", e)
+                        continue
                 else:
                     try:
                         out = confidence_model(complex_graph_batch)
-                    except AssertionError as e:
-                        print("Confidence model failed:", e, "-> using -2.0 score")
-                        out = torch.full((b,), -2.0, device=device)
-                    except Exception:
-                        raise
+                    except Exception as e:
+                        print("Skipping complex due to confidence model error:", e)
+                        continue
 
                 if type(out) is tuple:
                     out = out[0]


### PR DESCRIPTION
## Summary
- skip complexes if confidence model fails during sampling
- handle all exceptions during embedding inference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686735c94c6883228b45dd067bc2e803