### PR TITLE
Fix union type syntax and unify CLI

### DIFF
--- a/Diffdock_IC50_codes/README.md
+++ b/Diffdock_IC50_codes/README.md
@@ -251,7 +251,9 @@ python Diffdock_IC50_codes/finetune_regression_transformer.py dataset.pt run_dir
 To generate a dataset including docking and ESMFold embeddings run:
 
 ```bash
-python create_regression_transformer_input.py Diffdock_output Diffdock_output/Regression_transformer_input.csv dataset.pt
+python create_regression_transformer_input.py \
+    --out_dir Diffdock_output \
+    --protein_ligand_csv Diffdock_output/Regression_transformer_input.csv
 ```
 
 Each record stores embeddings for:

--- a/README.md
+++ b/README.md
@@ -115,12 +115,14 @@ python scripts/create_vocabulary.py examples/qed_property_example.txt examples/v
 #### Create dataset from DiffDock results
 DiffDock docking outputs can be converted into RT inputs with:
 ```console
-python create_regression_transformer_input.py Diffdock_output Diffdock_output/Regression_transformer_input.csv dataset.pt
+python create_regression_transformer_input.py \
+    --out_dir Diffdock_output \
+    --protein_ligand_csv Diffdock_output/Regression_transformer_input.csv
 ```
-The resulting ``dataset.pt`` contains tokenized sequences plus arrays with complex
-and protein embeddings. Placeholder tokens ``[comp_token]`` and
-``[protein_token]`` are automatically added to the vocabulary and replaced with
-these embeddings during training.
+The resulting ``dataset.pt`` (written inside ``Diffdock_output`` by default)
+contains tokenized sequences plus arrays with complex and protein embeddings.
+Placeholder tokens ``[comp_token]`` and ``[protein_token]`` are automatically
+added to the vocabulary and replaced with these embeddings during training.
 
 At this point the folder containing the vocabulary file can be used to load a tokenizer compatible with any `ExpressionBertTokenizer`:
 ```python


### PR DESCRIPTION
## Summary
- fix Python <3.10 incompatibility in `create_regression_transformer_input.py`
- refactor dataset creation script to use option based CLI
- update documentation for the new CLI

## Testing
- `python -m py_compile create_regression_transformer_input.py`
- `black create_regression_transformer_input.py` *(already formatted)*
- `flake8 create_regression_transformer_input.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694bda702083229a449fc57323148f