### PR TITLE
Fix alt training NoneType error and set tokenizer class

### DIFF
--- a/models/Diffdock_RT/config.json
+++ b/models/Diffdock_RT/config.json
@@ -40,5 +40,6 @@
   "untie_r": true,
   "use_ne": true,
   "vmax": 1.0,
-  "vocab_size": 507
+"vocab_size": 507
+ ,"tokenizer_class": "ExpressionBertTokenizer"
 }

--- a/models/Diffdock_RT/tokenizer_config.json
+++ b/models/Diffdock_RT/tokenizer_config.json
@@ -1,1 +1,1 @@
-{"language": "SELFIES", "special_tokens_map_file": null, "full_tokenizer_file": null}
+{"language": "SELFIES", "special_tokens_map_file": null, "full_tokenizer_file": null, "tokenizer_class": "ExpressionBertTokenizer"}

--- a/models/qed/config.json
+++ b/models/qed/config.json
@@ -40,5 +40,6 @@
   "untie_r": true,
   "use_ne": true,
   "vmax": 1.0,
-  "vocab_size": 507
+"vocab_size": 507
+ ,"tokenizer_class": "ExpressionBertTokenizer"
 }

--- a/models/qed/tokenizer_config.json
+++ b/models/qed/tokenizer_config.json
@@ -1,1 +1,1 @@
-{"language": "SELFIES", "special_tokens_map_file": null, "full_tokenizer_file": null}
+{"language": "SELFIES", "special_tokens_map_file": null, "full_tokenizer_file": null, "tokenizer_class": "ExpressionBertTokenizer"}

--- a/terminator/trainer.py
+++ b/terminator/trainer.py
@@ -172,11 +172,12 @@ class CustomTrainer(Trainer):
                     f"Combination of alternate steps {self.alternate_steps} and logging"
                     f" steps ({self.args.logging_steps}) would break best-model-saving."
                 )
+            eval_steps = self.args.eval_accumulation_steps or 1
             if (
                 self.args.gradient_accumulation_steps > self.alternate_steps
-                or self.args.eval_accumulation_steps > self.alternate_steps
+                or eval_steps > self.alternate_steps
                 or self.alternate_steps % self.args.gradient_accumulation_steps != 0
-                or self.alternate_steps % self.args.eval_accumulation_steps != 0
+                or self.alternate_steps % eval_steps != 0
             ):
                 raise ValueError(
                     f"Combination of alternate steps ({self.alternate_steps}) & gradient"


### PR DESCRIPTION
## Summary
- handle `eval_accumulation_steps` when None in `CustomTrainer`
- declare `ExpressionBertTokenizer` as tokenizer class in configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d0624af48322bc60472f31c051ec