### PR TITLE
Fix DDP init in trainer

### DIFF
--- a/terminator/trainer.py
+++ b/terminator/trainer.py
@@ -925,6 +925,9 @@ class CustomTrainer(Trainer):
 
         # Distributed training (should be after apex fp16 initialization)
         if self.args.local_rank != -1:
+            if not torch.distributed.is_initialized():
+                backend = "nccl" if torch.cuda.is_available() else "gloo"
+                torch.distributed.init_process_group(backend=backend)
             model = torch.nn.parallel.DistributedDataParallel(
                 model,
                 device_ids=[self.args.local_rank],


### PR DESCRIPTION
## Summary
- init process group before wrapping model with DistributedDataParallel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d6586aa88322a08d5b7a4c8f7d68