### PR TITLE
Fix DDP initialization on single GPU

### DIFF
--- a/finetune_regression_transformer.py
+++ b/finetune_regression_transformer.py
@@ -166,6 +166,7 @@ def main():
     if (
         training_args.local_rank != -1
         and world_size > 1
+        and os.environ.get("RANK") is not None
         and not torch.distributed.is_initialized()
     ):
         backend = "nccl" if torch.cuda.is_available() else "gloo"

--- a/terminator/trainer_utils.py
+++ b/terminator/trainer_utils.py
@@ -266,6 +266,9 @@ def distributed_concat(
             return type(tensor)(
                 distributed_concat(t, num_total_examples) for t in tensor
             )
+        if not torch.distributed.is_initialized():
+            raise AssertionError("Not currently using distributed training")
+
         output_tensors = [
             tensor.clone() for _ in range(torch.distributed.get_world_size())
         ]


### PR DESCRIPTION
## Summary
- avoid initializing torch.distributed when RANK isn't set
- guard distributed features behind `torch.distributed.is_initialized`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869db3123488322b3bbd68447c7611c